### PR TITLE
Fix default return value to get()

### DIFF
--- a/lacework-ingest/__init__.py
+++ b/lacework-ingest/__init__.py
@@ -19,7 +19,7 @@ def main(req: func.HttpRequest) -> func.HttpResponse:
             subaccount=subaccount
         )
         
-        alert = lacework_client.alerts.get_details(alert_id, "Details").get('data', [{}])
+        alert = lacework_client.alerts.get_details(alert_id, "Details").get('data', {})
         alert = dict((k.lower(), v) for k,v in alert.items())
         return alert
 


### PR DESCRIPTION
line 22 the default empty object to get() should be a dictionary, not a list for the alerts API